### PR TITLE
Set zoom level to 9

### DIFF
--- a/blocks/nasa_modis/UP42Manifest.json
+++ b/blocks/nasa_modis/UP42Manifest.json
@@ -17,7 +17,7 @@
       "contains": {"type": "geometry"},
       "time": {"type": "dateRange", "default": null},
       "limit": {"type": "integer", "minimum": 1, "default": 1},
-      "zoom_level": {"type": "number", "default": 9}
+      "zoom_level": {"type": "integer", "minimum": 9, "maximum": 9, "default": 9}
     },
     "machine": {
       "type": "medium"


### PR DESCRIPTION
The GIBS server only accepts zoom level 9 for this dataset