### PR TITLE
Restrict future dates up4850

### DIFF
--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">88%</text>
-        <text x="80" y="14">88%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
+        <text x="80" y="14">89%</text>
     </g>
 </svg>

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,3 +1,3 @@
 {
-  "publicVersion": "2.1.2"
+  "publicVersion": "2.1.3"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ shapely
 mercantile
 ciso8601
 python-dateutil
+pytz
 pytest
 pytest-mypy
 pytest-cov

--- a/src/gibs.py
+++ b/src/gibs.py
@@ -40,7 +40,7 @@ def move_dates_to_past(date_points: list) -> list:
     days_to_move = date_points[-1] - yesterday
 
     if days_to_move > timedelta(days=0):
-        date_points = [date_point - days_to_move for date_point in date_points]
+        date_points = [date_points[0], date_points[1] - days_to_move]
     return date_points
 
 

--- a/src/gibs.py
+++ b/src/gibs.py
@@ -1,7 +1,6 @@
 import collections
-import datetime
 import tempfile
-from datetime import timedelta
+from datetime import datetime, timedelta
 from io import BytesIO
 from pathlib import Path
 from typing import IO, Any, List, Tuple
@@ -12,6 +11,7 @@ import rasterio as rio
 import requests
 import xmltodict
 from dateutil import parser
+import pytz
 from rasterio.merge import merge
 from requests import Response
 from shapely.geometry import box
@@ -24,6 +24,24 @@ logger = get_logger(__name__)
 
 class WMTSException(Exception):
     pass
+
+
+def move_dates_to_past(date_points: list) -> list:
+    """
+    Moves dates to the past counting backwards from yesterday if the requested date range extends
+    into the future
+    Args:
+        date_strings -- list of dates
+
+    Returns:
+        list of dates
+    """
+    yesterday = (datetime.utcnow() - timedelta(days=1)).replace(tzinfo=pytz.UTC)
+    days_to_move = date_points[-1] - yesterday
+
+    if days_to_move > timedelta(days=0):
+        date_points = [date_point - days_to_move for date_point in date_points]
+    return date_points
 
 
 def extract_query_dates(query: STACQuery) -> list:
@@ -40,7 +58,7 @@ def extract_query_dates(query: STACQuery) -> list:
 
     if query.time is None:
         # Return latest [limit] dates counting from yesterday backwards
-        now = datetime.datetime.now()
+        now = datetime.utcnow()
         date_list = sorted(
             [
                 (now - timedelta(days=idx + 1)).strftime("%Y-%m-%d")
@@ -48,9 +66,10 @@ def extract_query_dates(query: STACQuery) -> list:
             ]
         )
     else:
-        # time is set, first check if it is an interval or only one point in time
         date_strings = str(query.time).split("/")
+        # time is set, first check if it is an interval or only one point in time
         date_points = [parser.parse(date_str) for date_str in date_strings]
+        date_points = move_dates_to_past(date_points)
         if len(date_points) == 2:
             time_diff = date_points[1] - date_points[0]
             days_in_interval = time_diff.days + bool(time_diff.seconds)

--- a/tests/context.py
+++ b/tests/context.py
@@ -14,5 +14,10 @@ from blockutils.stac import STACQuery
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
 
-from src.gibs import GibsAPI, extract_query_dates, make_list_layer_band
+from src.gibs import (
+    GibsAPI,
+    extract_query_dates,
+    make_list_layer_band,
+    move_dates_to_past,
+)
 from src.modis import Modis

--- a/tests/test_gibs.py
+++ b/tests/test_gibs.py
@@ -12,11 +12,13 @@ import rasterio as rio
 from rasterio.crs import CRS
 from rasterio.transform import Affine
 from PIL import Image
+import pytz
 
 import requests_mock as mock
 from blockutils.geometry import meta_is_equal
 from context import (
     GibsAPI,
+    move_dates_to_past,
     extract_query_dates,
     ensure_data_directories_exist,
     STACQuery,
@@ -110,6 +112,19 @@ def test_validate_imagery_layers(requests_mock):
     assert invalid[1] == [
         "POLYGON ((180 -85.051129, 180 85.051129, -180 85.051129, -180 -85.051129, 180 -85.051129))"
     ]
+
+
+def test_move_dates_to_past():
+
+    date_points = [datetime(2019, 4, 20, 16, 40, 49), datetime(2029, 4, 25, 17, 45, 49)]
+    date_points = [date_point.replace(tzinfo=pytz.UTC) for date_point in date_points]
+    updated_dates = move_dates_to_past(date_points)
+
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    expected_dates = [datetime(2019, 4, 20, 16, 40, 49), yesterday]
+    expected_dates = [date_point.replace(tzinfo=pytz.UTC) for date_point in expected_dates]
+
+    assert updated_dates == expected_dates
 
 
 def test_extract_query_dates():

--- a/tests/test_gibs.py
+++ b/tests/test_gibs.py
@@ -121,8 +121,8 @@ def test_extract_query_dates():
     (4) time is set to one point in time (not a period)
     (5) time is set to a period ending in the future
     """
-    yesterday = (datetime.utcnow()-timedelta(days=1)).strftime('%Y-%m-%d')
-    day_before_yesterday = (datetime.utcnow() - timedelta(days=2)).strftime('%Y-%m-%d')
+    yesterday = (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
+    day_before_yesterday = (datetime.utcnow() - timedelta(days=2)).strftime("%Y-%m-%d")
 
     # case (1)
     query = STACQuery.from_dict(

--- a/tests/test_gibs.py
+++ b/tests/test_gibs.py
@@ -120,11 +120,12 @@ def test_move_dates_to_past():
     date_points = [date_point.replace(tzinfo=pytz.UTC) for date_point in date_points]
     updated_dates = move_dates_to_past(date_points)
 
-    yesterday = datetime.utcnow() - timedelta(days=1)
-    expected_dates = [datetime(2019, 4, 20, 16, 40, 49), yesterday]
-    expected_dates = [date_point.replace(tzinfo=pytz.UTC) for date_point in expected_dates]
+    yesterday = (datetime.utcnow() - timedelta(days=1)).replace(tzinfo=pytz.UTC)
+    expected_dates = [date_points[0], yesterday]
+    updated_dates_str = [date.strftime("%Y-%m-%d") for date in updated_dates]
+    expected_dates_str = [date.strftime("%Y-%m-%d") for date in expected_dates]
 
-    assert updated_dates == expected_dates
+    assert updated_dates_str == expected_dates_str
 
 
 def test_extract_query_dates():


### PR DESCRIPTION
After the addition of a default timestamp the block only delivered empty images per default, as future dates were requested. The GIBS server is tolerant in this regard, the returned tiles are simply empty.
The fix is that we do not allow to query for future dates any more.