### PR TITLE
Cog modis up5323

### DIFF
--- a/UP42Manifest.json
+++ b/UP42Manifest.json
@@ -15,7 +15,7 @@
       "bbox": {"type": "array", "default": null},
       "intersects": {"type": "geometry"},
       "contains": {"type": "geometry"},
-      "time": {"type": "dateRange", "default": "2018-12-01T00:00:00+00:00/2020-12-31T23:59:59+00:00"},
+      "time": {"type": "dateRange", "default": "2018-12-01T00:00:00+00:00/2021-02-15T23:59:59+00:00"},
       "limit": {"type": "integer", "minimum": 1, "default": 1},
       "zoom_level": {"type": "integer", "minimum": 9, "maximum": 9, "default": 9},
       "imagery_layers": {"type": "array", "default": ["MODIS_Terra_CorrectedReflectance_TrueColor"]}

--- a/UP42Manifest.json
+++ b/UP42Manifest.json
@@ -15,7 +15,7 @@
       "bbox": {"type": "array", "default": null},
       "intersects": {"type": "geometry"},
       "contains": {"type": "geometry"},
-      "time": {"type": "dateRange", "default": "2018-12-01T00:00:00+00:00/2021-02-15T23:59:59+00:00"},
+      "time": {"type": "dateRange", "default": "2018-12-01T00:00:00+00:00/2021-12-31T23:59:59+00:00"},
       "limit": {"type": "integer", "minimum": 1, "default": 1},
       "zoom_level": {"type": "integer", "minimum": 9, "maximum": 9, "default": 9},
       "imagery_layers": {"type": "array", "default": ["MODIS_Terra_CorrectedReflectance_TrueColor"]}

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">90%</text>
-        <text x="80" y="14">90%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
+        <text x="80" y="14">91%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
-        <text x="80" y="14">91%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">90%</text>
+        <text x="80" y="14">90%</text>
     </g>
 </svg>

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,3 +1,3 @@
 {
-  "publicVersion": "2.2.1"
+  "publicVersion": "2.2.2"
 }

--- a/src/gibs.py
+++ b/src/gibs.py
@@ -11,6 +11,7 @@ import xmltodict
 from dateutil import parser
 from requests import Response
 from shapely.geometry import box
+from rasterio.enums import ColorInterp
 
 from blockutils.exceptions import SupportedErrors, UP42Error
 from blockutils.logging import get_logger
@@ -286,6 +287,17 @@ class GibsAPI:
             img_bands_count = dst.count
             for band in make_list_layer_band(imagery_layers, img_bands_count):
                 dst.update_tags(band[0], layer=band[1], band=band[2])
+            color_interp = [
+                ColorInterp.red,
+                ColorInterp.green,
+                ColorInterp.blue
+            ]
+            if img_bands_count > 3:
+                for i in range(img_bands_count-3):
+                    color_interp.append(ColorInterp.undefined)
+
+            dst.colorinterp = color_interp[:img_bands_count]
+
 
     def get_layer_bands_count(self, tile_list, imagery_layers, date):
         for layer in imagery_layers:

--- a/src/gibs.py
+++ b/src/gibs.py
@@ -287,6 +287,8 @@ class GibsAPI:
             img_bands_count = dst.count
             for band in make_list_layer_band(imagery_layers, img_bands_count):
                 dst.update_tags(band[0], layer=band[1], band=band[2])
+            # The COG conversion assumes last band is an alpha band therefore It's necessary to define the ColorInterp
+            # property
             color_interp = [ColorInterp.red, ColorInterp.green, ColorInterp.blue]
             if img_bands_count > 3:
                 for _ in range(img_bands_count - 3):

--- a/src/gibs.py
+++ b/src/gibs.py
@@ -287,17 +287,12 @@ class GibsAPI:
             img_bands_count = dst.count
             for band in make_list_layer_band(imagery_layers, img_bands_count):
                 dst.update_tags(band[0], layer=band[1], band=band[2])
-            color_interp = [
-                ColorInterp.red,
-                ColorInterp.green,
-                ColorInterp.blue
-            ]
+            color_interp = [ColorInterp.red, ColorInterp.green, ColorInterp.blue]
             if img_bands_count > 3:
-                for i in range(img_bands_count-3):
+                for _ in range(img_bands_count - 3):
                     color_interp.append(ColorInterp.undefined)
 
             dst.colorinterp = color_interp[:img_bands_count]
-
 
     def get_layer_bands_count(self, tile_list, imagery_layers, date):
         for layer in imagery_layers:

--- a/src/modis.py
+++ b/src/modis.py
@@ -7,6 +7,7 @@ import mercantile
 from mercantile import Tile
 from mercantile import MercantileError
 import requests
+from rasterio.enums import ColorInterp
 from geojson import Feature, FeatureCollection
 from shapely.geometry import box
 from shapely.ops import unary_union
@@ -18,6 +19,8 @@ from blockutils.logging import get_logger
 from blockutils.stac import STACQuery
 from blockutils.wmts import MultiTileMergeHelper
 from blockutils.datapath import set_data_path
+
+from blockutils.raster import to_cog
 
 from gibs import GibsAPI, extract_query_dates
 
@@ -122,6 +125,7 @@ class Modis(DataBlock):
                     tile_list, valid_imagery_layers, query_date, feature_id
                 )
                 self.api.post_process(img_filename, valid_imagery_layers)
+                to_cog(img_filename)
                 set_data_path(feature, f"{feature_id}.tif")
 
             logger.debug(feature)

--- a/src/modis.py
+++ b/src/modis.py
@@ -7,7 +7,6 @@ import mercantile
 from mercantile import Tile
 from mercantile import MercantileError
 import requests
-from rasterio.enums import ColorInterp
 from geojson import Feature, FeatureCollection
 from shapely.geometry import box
 from shapely.ops import unary_union
@@ -125,7 +124,7 @@ class Modis(DataBlock):
                     tile_list, valid_imagery_layers, query_date, feature_id
                 )
                 self.api.post_process(img_filename, valid_imagery_layers)
-                to_cog(img_filename)
+                to_cog(img_filename, forward_band_tags=True)
                 set_data_path(feature, f"{feature_id}.tif")
 
             logger.debug(feature)

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -9,6 +9,7 @@ import re
 import rasterio as rio
 import numpy as np
 import pytest
+from rio_cogeo.cogeo import cog_validate
 
 from context import STACQuery, Modis
 
@@ -348,6 +349,7 @@ def test_aoiclipped_fetcher_virs_fetch_live(modis_instance):
     with rio.open(img_filename) as dataset:
         band1 = dataset.read(1)
         assert np.sum(band1) == 45232508
+        # np.sum(dataset.read(1))
         assert dataset.count == 1
     assert os.path.isfile("/tmp/quicklooks/%s.jpg" % result.features[0]["id"])
 
@@ -429,6 +431,7 @@ def test_aoiclipped_fetcher_multiple_fetch_live(modis_instance):
         assert np.sum(band2) == 28351388
         assert dataset.count == 6
     assert os.path.isfile("/tmp/quicklooks/%s.jpg" % result.features[0]["id"])
+    assert cog_validate(img_filename)[0] is True
 
 
 @pytest.mark.live

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -175,6 +175,7 @@ def test_aoiclipped_fetcher_fetch(requests_mock, modis_instance):
     assert len(result.features) == 1
 
     img_filename = "/tmp/output/%s" % result.features[0]["properties"]["up42.data_path"]
+    assert cog_validate(img_filename)[0] is True
     with rio.open(img_filename) as dataset:
         band2 = dataset.read(2)
         assert np.sum(band2) == 7954025
@@ -349,9 +350,9 @@ def test_aoiclipped_fetcher_virs_fetch_live(modis_instance):
     with rio.open(img_filename) as dataset:
         band1 = dataset.read(1)
         assert np.sum(band1) == 45232508
-        # np.sum(dataset.read(1))
         assert dataset.count == 1
     assert os.path.isfile("/tmp/quicklooks/%s.jpg" % result.features[0]["id"])
+    assert cog_validate(img_filename)[0] is True
 
 
 @pytest.mark.live
@@ -480,3 +481,36 @@ def test_aoiclipped_fetcher_geom_error_fetch_live(modis_instance):
 
     with pytest.raises(UP42Error):
         modis_instance.fetch(query, dry_run=False)
+
+
+@pytest.mark.live
+def test_aoiclipped_fetcher_layers_cog(modis_instance):
+    """
+    Unmocked ("live") test for fetching data, error in geometry of layer
+    """
+
+    query = STACQuery.from_dict(
+        {
+            "zoom_level": 9,
+            "time": "2019-01-01T16:40:49+00:00/2021-02-15T23:59:59+00:00",
+            "limit": 1,
+            "bbox": [
+                38.941807150840766,
+                21.288749561718983,
+                39.686130881309516,
+                21.808610762909364,
+            ],
+            "imagery_layers": [
+                "MODIS_Terra_CorrectedReflectance_TrueColor",
+                "MODIS_Terra_EVI_8Day",
+                "MODIS_Terra_CorrectedReflectance_Bands721",
+            ],
+        }
+    )
+
+    result = modis_instance.fetch(query, dry_run=False)
+    assert len(result.features) == 1
+    img_filename = "/tmp/output/%s" % result.features[0]["properties"]["up42.data_path"]
+    with rio.open(img_filename) as dataset:
+        assert dataset.count == 7
+    assert cog_validate(img_filename)[0] is True

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -486,7 +486,7 @@ def test_aoiclipped_fetcher_geom_error_fetch_live(modis_instance):
 @pytest.mark.live
 def test_aoiclipped_fetcher_layers_cog(modis_instance):
     """
-    Unmocked ("live") test for fetching data, error in geometry of layer
+    Unmocked ("live") test for fetching data. Tests cog conversion with image, with 7 bands.
     """
 
     query = STACQuery.from_dict(
@@ -512,5 +512,7 @@ def test_aoiclipped_fetcher_layers_cog(modis_instance):
     assert len(result.features) == 1
     img_filename = "/tmp/output/%s" % result.features[0]["properties"]["up42.data_path"]
     with rio.open(img_filename) as dataset:
+        band2 = dataset.read(2)
+        assert np.sum(band2) == 28202042
         assert dataset.count == 7
     assert cog_validate(img_filename)[0] is True

--- a/tests/test_modis.py
+++ b/tests/test_modis.py
@@ -175,7 +175,7 @@ def test_aoiclipped_fetcher_fetch(requests_mock, modis_instance):
     assert len(result.features) == 1
 
     img_filename = "/tmp/output/%s" % result.features[0]["properties"]["up42.data_path"]
-    assert cog_validate(img_filename)[0] is True
+    assert cog_validate(img_filename)[0]
     with rio.open(img_filename) as dataset:
         band2 = dataset.read(2)
         assert np.sum(band2) == 7954025
@@ -352,7 +352,7 @@ def test_aoiclipped_fetcher_virs_fetch_live(modis_instance):
         assert np.sum(band1) == 45232508
         assert dataset.count == 1
     assert os.path.isfile("/tmp/quicklooks/%s.jpg" % result.features[0]["id"])
-    assert cog_validate(img_filename)[0] is True
+    assert cog_validate(img_filename)[0]
 
 
 @pytest.mark.live
@@ -432,7 +432,7 @@ def test_aoiclipped_fetcher_multiple_fetch_live(modis_instance):
         assert np.sum(band2) == 28351388
         assert dataset.count == 6
     assert os.path.isfile("/tmp/quicklooks/%s.jpg" % result.features[0]["id"])
-    assert cog_validate(img_filename)[0] is True
+    assert cog_validate(img_filename)[0]
 
 
 @pytest.mark.live
@@ -515,4 +515,4 @@ def test_aoiclipped_fetcher_layers_cog(modis_instance):
         band2 = dataset.read(2)
         assert np.sum(band2) == 28202042
         assert dataset.count == 7
-    assert cog_validate(img_filename)[0] is True
+    assert cog_validate(img_filename)[0]


### PR DESCRIPTION
This PR adresses the following ticket: https://app.circleci.com/pipelines/github/up42/blocks/5043/workflows/48141538-af55-4e0e-adcd-5d3cda3e3d1e/jobs/9885.

For the Modis Block It was necessary to define the bands using ColorInterpret, as the COG conversion with rasterio seems to incorrectly assume that the last band is an alpha band.

Items:
* [ ] ...
* [x] Ran e2e and live-tests for updated blocks
* [x] Add units tests
* [x] Bumped block versions